### PR TITLE
Remove broken vaadin-pre-release repository link (#16)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,6 @@
         </license>
     </licenses>
 
-    <repositories>
-        <repository>
-            <id>vaadin-pre-release</id>
-            <url>http://maven.vaadin.com/vaadin-prereleases/com/vaadin/</url>
-        </repository>
-    </repositories>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
The vaadin-pre-release repository url http://maven.vaadin.com/vaadin-prereleases/com/vaadin/ seems to be broken.

Maven is trying to download http://maven.vaadin.com/vaadin-prereleases/com/vaadin/com/vaadin/vaadin-bom/10.0.0.beta9/vaadin-bom-10.0.0.beta9.pom (com/vaadin/ x 2).

I removed the repository as it does not seem to be necessary since the addon depends on stable vaadin 10 now.