### PR TITLE
Fix start index to subList to avoid IndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/vaadin/artur/spring/dataprovider/PageableDataProvider.java
+++ b/src/main/java/org/vaadin/artur/spring/dataprovider/PageableDataProvider.java
@@ -93,6 +93,9 @@ public abstract class PageableDataProvider<T, F>
         if (afterLastReal > items.size()) {
             afterLastReal = items.size();
         }
+        if (firstReal < 0 || firstReal > afterLastReal) {
+            firstReal = 0;
+        }
         return items.subList(firstReal, afterLastReal).stream();
     }
 


### PR DESCRIPTION
I ran into this issue in vaadin 8 where sometimes the start index was larger than the end index resulting in IndexOutOfBoundsException.